### PR TITLE
chore: Add supernode docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,5 +29,5 @@
 	branch = main
 [submodule "submodules/metis"]
 	path = submodules/metis
-	url = git@github.com:txpipe/metis.git
+	url = https://github.com/txpipe/metis.git
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,7 @@
 	path = submodules/cshell
 	url = https://github.com/txpipe/cshell
 	branch = main
+[submodule "submodules/metis"]
+	path = submodules/metis
+	url = git@github.com:txpipe/metis.git
+	branch = main

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,6 +38,10 @@ export default defineConfig({
           autogenerate: { directory: 'dolos', collapsed: true },
         },
         {
+          label: 'Supernode',
+          autogenerate: { directory: 'metis', collapsed: true },
+        },
+        {
           label: 'Griffin',
           autogenerate: { directory: 'griffin', collapsed: true },
         },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,7 +38,7 @@ export default defineConfig({
           autogenerate: { directory: 'dolos', collapsed: true },
         },
         {
-          label: 'Supernode',
+          label: 'Metis',
           autogenerate: { directory: 'metis', collapsed: true },
         },
         {

--- a/public/assets/metis
+++ b/public/assets/metis
@@ -1,0 +1,1 @@
+../../submodules/metis/docs/assets

--- a/src/content/docs/metis
+++ b/src/content/docs/metis
@@ -1,0 +1,1 @@
+../../../submodules/metis/docs/content

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,6 +20,7 @@ const tools = [
   { name: 'Griffin', link: '/griffin' },
   { name: 'Tx3', link: '/tx3' },
   { name: 'UTxORPC', link: 'https://utxorpc.org/introduction' },
+  { name: 'Metis (Supernode)', link: '/metis' },
 ];
 
 const tasks = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Metis (Supernode) documentation section to the sidebar with auto-generated pages (collapsed by default).
  * Added a Metis (Supernode) tool entry to the homepage tool navigation, creating a new “By Tool” chip linking to the Metis docs.
  * Exposed Metis documentation assets for public site use.

* **Chores**
  * Integrated external Metis documentation source into the site repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->